### PR TITLE
disable auto rehash for mysql client

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,11 @@ cat > /etc/mysql/conf.d/max_connections.cnf <<MAX_CONN
 max_connections = $MYSQL_MAX_CONNECTIONS
 MAX_CONN
 
+cat > /etc/mysql/conf.d/disable_auto_rehash.cnf <<DAR
+[mysql]
+disable_auto_rehash
+DAR
+
 # /entrypoint.sh is present in mysql official docker image, and configures
 # the initial db and then starts mysqld, when the parameter passed is mysqld
 # (with optional flags)


### PR DESCRIPTION
MySQL scans database, tables and columns name for auto completion. If you have many db, tables it could take a while. To avoid that, launch your client with the -A option (or --no-auto-rehash). You could also add the disable_auto_rehash variable in your my.cnf (in the [mysql] section) if you want to disable it completely.
