### PR TITLE
avoid having 'sh -c "..."' as pid 1 (init) in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ RUN \
 
 COPY ["start.sh", "/tmp/"]
 
-CMD /tmp/start.sh
+CMD ["/tmp/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -16,4 +16,4 @@ DAR
 # /entrypoint.sh is present in mysql official docker image, and configures
 # the initial db and then starts mysqld, when the parameter passed is mysqld
 # (with optional flags)
-eyeos-run-server --serf --skip-dnsmasq "/entrypoint.sh mysqld"
+exec eyeos-run-server --serf --skip-dnsmasq "/entrypoint.sh mysqld"


### PR DESCRIPTION
Facts:
- Pid 1 is the one that receives SIGTERM when we run `docker stop`.
- Shell scripts swallow signals.
- If the `CMD` sentence in `Dockerfile` is not in the form of a JSON
  array, docker launches a shell to execute the `CMD`, using `sh -c
  "$CMD"`.

So, our pid 1 in the container was a `sh -c "..."` process, that did not
pass signals to `eyeos-run-server`, so `eyeos-run-server` never received
a `SIGTERM` when someone did `docker stop`, and docker ended up killing
our containers in a not-so-graceful way.

To avoid this, we need to specify the `CMD` in "execform" (see
https://docs.docker.com/engine/reference/builder/#cmd) so the pid 1
process in the container is our command instead of a wrapping `sh -c`.
In the CMD sentence, environment variables are not expanded, so we
cannot use `${InstallationDir}` or others there now (we could do that
before because the literal `${InstallationDir}` was passed to the shell,
and the shell was evaluating it, but now that no shell is present we
cannot use envars in the `CMD`. To avoid this we set a shell script as
our CMD, and in the script we `exec` the full command that we had on the
initial CMD. The `exec` part is very important, because this makes the
new process to replace the script process, so now eyeos-run-server is
the new pid 1 process, and it will receive all signals.
